### PR TITLE
BOP-21 画像ファイルがコミットされていなかった件の対応

### DIFF
--- a/AndroidPOS/res/layout/activity_category_twopane.xml
+++ b/AndroidPOS/res/layout/activity_category_twopane.xml
@@ -36,7 +36,7 @@
                 <ImageView
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
-                    android:src="@drawable/ic_search"
+                    android:src="@android:drawable/ic_menu_search"
                     android:scaleType="fitStart"
                     />
             </FrameLayout>


### PR DESCRIPTION
Android標準の検索アイコンを使うように修正しました。
