### PR TITLE
BOP-29 sales.csvがMTPですぐに見られるようにする対応

### DIFF
--- a/AndroidPOS/src/com/ricoh/pos/DataSyncTask.java
+++ b/AndroidPOS/src/com/ricoh/pos/DataSyncTask.java
@@ -64,7 +64,7 @@ public class DataSyncTask extends AsyncTask<String, Void, AsyncTaskResult<String
             return AsyncTaskResult.createErrorResult(R.string.sd_import_error);
         }
         try {
-			WomanShopSalesIOManager.getInstance().exportCSV();
+			WomanShopSalesIOManager.getInstance().exportCSV(this.context);
 		} catch (Exception e) {
 			Log.d("debug", "export error", e);
 			return AsyncTaskResult.createErrorResult(R.string.sd_export_error);

--- a/AndroidPOS/src/com/ricoh/pos/model/WomanShopSalesIOManager.java
+++ b/AndroidPOS/src/com/ricoh/pos/model/WomanShopSalesIOManager.java
@@ -41,7 +41,7 @@ public class WomanShopSalesIOManager {
     /** DBに格納する時の日付けフォーマット */
     private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
 
-    /** csファイルのMIMタイプ **/
+    /** csvファイルのMIMEタイプ **/
     private static final String CSV_MIME_TYPE = "text/comma-separated-values";
 
     //------------------------ private -----------------------------

--- a/AndroidPOS/src/com/ricoh/pos/model/WomanShopSalesIOManager.java
+++ b/AndroidPOS/src/com/ricoh/pos/model/WomanShopSalesIOManager.java
@@ -496,9 +496,8 @@ public class WomanShopSalesIOManager {
                     Log.d("MediaScannerConnection", "-> uri=" + uri);
                 }
             };
-            String targetMimeType = CSV_MIME_TYPE;
             String[] paths = { Environment.getExternalStorageDirectory().getPath() + CSV_STORAGE_FOLDER + SALES_CSV_FILE_NAME };
-            String[] mimeTypes = { targetMimeType };
+            String[] mimeTypes = { CSV_MIME_TYPE };
             MediaScannerConnection.scanFile(context, paths, mimeTypes, mScanCompletedListener);
         }
     }


### PR DESCRIPTION
sales.csv更新時にAndroidのメディアストレージに更新をかけるようにしました。
・注意点として、MTPへの更新タイミングはUSB接続時です。
（USB接続中にsyncボタンを押下しても、エクスプローラーで開けるsales.csvは更新されません。USBの抜き差しが必要です。）
