### PR TITLE
BOP-36対応。

### DIFF
--- a/AndroidPOS/src/com/ricoh/pos/model/WomanShopSalesIOManager.java
+++ b/AndroidPOS/src/com/ricoh/pos/model/WomanShopSalesIOManager.java
@@ -18,6 +18,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.UnsupportedEncodingException;
+import java.math.BigDecimal;
 import java.sql.SQLException;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -456,13 +457,17 @@ public class WomanShopSalesIOManager {
                         Order order = orders.get(orderNo);
                         Product product = order.getProduct();
 
+                        BigDecimal priceBD = new BigDecimal(product.getPrice());
+                        BigDecimal totalBD = new BigDecimal(product.getPrice() * order.getNumberOfOrder());
+                        BigDecimal discountBD = new BigDecimal(record.getDiscountValue());
+
                         String result = product.getCode() + ","
                                 + product.getCategory() + ","
                                 + product.getName() + ","
                                 + order.getNumberOfOrder() + ","
-                                + String.format("%.2f", product.getPrice()) + ","
-                                + String.format("%.2f", product.getPrice() * order.getNumberOfOrder()) + ","
-                                + String.format("%.2f", record.getDiscountValue()) + ","
+                                + priceBD.setScale(2, BigDecimal.ROUND_HALF_UP) + ","
+                                + totalBD.setScale(2, BigDecimal.ROUND_HALF_UP) + ","
+                                + discountBD.setScale(2, BigDecimal.ROUND_HALF_UP) + ","
                                 + record.getSalesDate().toString() + ","
                                 + record.getUserAttribute() + "\n";
 

--- a/AndroidPOS/src/com/ricoh/pos/model/WomanShopSalesIOManager.java
+++ b/AndroidPOS/src/com/ricoh/pos/model/WomanShopSalesIOManager.java
@@ -460,9 +460,9 @@ public class WomanShopSalesIOManager {
                                 + product.getCategory() + ","
                                 + product.getName() + ","
                                 + order.getNumberOfOrder() + ","
-                                + product.getPrice() + ","
-                                + product.getPrice() * order.getNumberOfOrder() + ","
-                                + record.getDiscountValue() + ","
+                                + String.format("%.2f", product.getPrice()) + ","
+                                + String.format("%.2f", product.getPrice() * order.getNumberOfOrder()) + ","
+                                + String.format("%.2f", record.getDiscountValue()) + ","
                                 + record.getSalesDate().toString() + ","
                                 + record.getUserAttribute() + "\n";
 


### PR DESCRIPTION
CSV出力時に小数2位までに丸めるようにした。
仕様上、小数2位より小さい数は使用しないはず。

SQLiteのREAL型は有効桁64bit＝doubleと同じ。
かつ、以前のアプリもProductクラスはdoubleを使用していたので、トータル金額を計算する掛け算でのみ誤差が生じると思われるが、念のためdouble型を使う部分をformatした。

課題の計算の他3パターンくらいで動作検証済み。
https://developer.osaroid.info/jira/browse/BOP-36
