### PR TITLE
BOP-44対応。

### DIFF
--- a/AndroidPOS/src/com/ricoh/pos/RegisterConfirmActivity.java
+++ b/AndroidPOS/src/com/ricoh/pos/RegisterConfirmActivity.java
@@ -66,6 +66,7 @@ implements RegisterConfirmFragment.OnButtonClickListener,OrderListFragment.OnOrd
 		if(RegisterManager.getInstance().getOriginalTotalAmount() != 0){
 			// Save this sales record
 			SingleSalesRecord record = RegisterManager.getInstance().getSingleSalesRecord();
+			record.calcDiscountAllocation(); // 値引き割り当ての実施
 			SalesRecordManager.getInstance().storeSingleSalesRecord(salesDatabase, record);
 		}
 		

--- a/AndroidPOS/src/com/ricoh/pos/SalesDatabaseHelper.java
+++ b/AndroidPOS/src/com/ricoh/pos/SalesDatabaseHelper.java
@@ -40,6 +40,7 @@ public class SalesDatabaseHelper extends SQLiteOpenHelper {
                         + WomanShopSalesOrderDef.PURCHASE_PRICE.name() + " Real, "
                         + WomanShopSalesOrderDef.UNIT_PRICE.name() + " Real, "
                         + WomanShopSalesOrderDef.QTY.name() + " Integer, "
+                        + WomanShopSalesOrderDef.DISCOUNT.name() + " Real, "
                         + WomanShopSalesOrderDef.SINGLE_SALES_ID.name() + " Integer)"
         );
         Log.d("debug", "SingleSalesOrder table onCreate");

--- a/AndroidPOS/src/com/ricoh/pos/data/Order.java
+++ b/AndroidPOS/src/com/ricoh/pos/data/Order.java
@@ -1,27 +1,22 @@
 package com.ricoh.pos.data;
 
-public class Order {
-	
+public class Order
+{
 	private Product product;
-	
 	private int num;
-	
-	public Order() {
-		// Do nothing
-	}
-	
-	public Order(Product product,int numberOfOrder){
-		
+	private double discountValue;
+
+	public Order(Product product,int numberOfOrder)
+	{
 		if(product == null || numberOfOrder < 0) {
 			throw new IllegalArgumentException();
 		}
-		
 		setOrder(product,numberOfOrder);
 	}
 	
-	public void setOrder(Product product,int numberOfOrder){
-		
-		if(product == null || numberOfOrder < 0) {
+	public void setOrder(Product product,int numberOfOrder)
+	{
+		if (product == null || numberOfOrder < 0) {
 			throw new IllegalArgumentException();
 		}
 		
@@ -29,7 +24,8 @@ public class Order {
 		this.num = numberOfOrder;
 	}
 	
-	public void setNumberOfOrder(int num){
+	public void setNumberOfOrder(int num)
+	{
 		if (num < 0) {
 			 throw new IllegalArgumentException("Number of order should be positive");
 		}
@@ -37,13 +33,15 @@ public class Order {
 		this.num = num;
 	}
 	
-	public void plusNumberOfOrder(){
+	public void plusNumberOfOrder()
+	{
 		num++;
 	}
 	
-	public void minusNumberOfOrder(){
+	public void minusNumberOfOrder()
+	{
 		if (num == 0) {
-			// Do Nothing		
+
 		} else if (num > 0) {
 			num--;
 		} else {
@@ -74,15 +72,30 @@ public class Order {
 	public double getProductPrice(){
 		return product.getPrice();
 	}
-	
+
 	public double getTotalAmount(){
 		return product.getPrice() * num;
 	}
-	
+
 	public double getTotalCost(){
 		return product.getOriginalCost() * num;
 	}
-	
+
+	public double getRevenue(boolean enableDisCount) {
+		double result = (product.getPrice() - product.getOriginalCost()) * num;
+		if (enableDisCount) {
+			return (result - discountValue);
+		}
+		return result;
+	}
+
+	public void setDiscount(double discount) {
+		discountValue = discount;
+	}
+	public double getDiscount() {
+		return discountValue;
+	}
+
 	protected boolean equals(String productName){
 		return productName.equals(product.getName());
 	}

--- a/AndroidPOS/src/com/ricoh/pos/data/Product.java
+++ b/AndroidPOS/src/com/ricoh/pos/data/Product.java
@@ -10,6 +10,10 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.InputStream;
 
+/**
+ * 商品データそのものを表すクラス
+ * 概ね、ドリシティの用意するCSVと互換
+ */
 public class Product {
 
 	private String code;

--- a/AndroidPOS/src/com/ricoh/pos/data/SingleSalesRecord.java
+++ b/AndroidPOS/src/com/ricoh/pos/data/SingleSalesRecord.java
@@ -1,15 +1,33 @@
 package com.ricoh.pos.data;
 
+import android.util.Log;
+
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Date;
 
+
+/**
+ * 販売1件を表すクラス。
+ * この中に複数のOrderが設定される
+ *
+ */
 public class SingleSalesRecord {
-	
+	/** 販売日時 */
 	private Date salesDate;
+
+	/** 値引き額 */
 	private double discountValue;
+
+	/**
+	 * ユーザー属性
+	 */
 	private String userAttribute;
+
+	/** Orderの配列 */
 	private ArrayList<Order> orders;
-	
+
+
 	public SingleSalesRecord(Date date){
 		orders = new ArrayList<Order>();
 		this.salesDate = date;
@@ -19,7 +37,11 @@ public class SingleSalesRecord {
 	public void setOrders(ArrayList<Order> orderList){
 		this.orders = orderList;
 	}
-	
+
+	public ArrayList<Order> getAllOrders(){
+		return orders;
+	}
+
 	public void addOrder(Order order){
 		if (order == null) {
 			throw new IllegalArgumentException("Order is null");
@@ -30,50 +52,97 @@ public class SingleSalesRecord {
 	public void setDiscountValue(double discountValue) {
 		this.discountValue = discountValue;
 	}
-	
-	public ArrayList<Order> getAllOrders(){
-		return orders;
+
+	public double getDiscountValue() {
+		return discountValue;
 	}
-	
-	public double getTotalSales(){
+
+	/**
+	 * 値引き額の総額を、個々のオーダーに割り振る処理。
+	 * これを通さないと、DBに割引額が反映されない。
+	 */
+	public void calcDiscountAllocation()
+	{
+		// discountValue = 0なら値引きしてないのでなにもしない
+		//　利益が無い＝既に値引き処理済とみなして何もしない
+		if (getTotalRevenue() <= 0 || discountValue <= 0) {
+			return;
+		}
+
+		double downPercent = discountValue / getTotalRevenue();
+		double totalDiscount = 0.0;
+
+		for (Order order : orders) {
+			// 小数2位で丸める
+			BigDecimal big = new BigDecimal(order.getRevenue(false) * downPercent);
+			double discount = big.setScale(2, BigDecimal.ROUND_HALF_UP).doubleValue();
+
+			Log.d("debug", "discount set " + order.getProductName() + " :" + discount);
+			order.setDiscount(discount);
+			totalDiscount += discount;
+		}
+
+		Log.d("debug", "discount total=" + totalDiscount + "/ set=" + discountValue);
+
+		// 端数がある場合の対処
+		if (totalDiscount != discountValue) {
+			// totalの方が大きい＝実際より大きく値引き額を設定＝値引き額を減らす必要がある
+			BigDecimal fraction = new BigDecimal(orders.get(0).getDiscount() - (totalDiscount - discountValue));
+			orders.get(0).setDiscount(fraction.setScale(2, BigDecimal.ROUND_HALF_UP).doubleValue());
+		}
+	}
+
+	/**
+	 * この販売の売り上げ金額を返す
+	 * @return
+	 */
+	public double getTotalSales() {
 		double totalSales = 0;
 		for (Order order : orders) {
 			totalSales += order.getTotalAmount();
 		}
 		return totalSales;
 	}
-	
-	public double getTotalCost(){
+
+	/**
+	 * この販売の原価を計算する
+	 * @return double 原価
+	 */
+	public double getTotalCost() {
 		double totalCost = 0;
 		for (Order order : orders) {
 			totalCost += order.getTotalCost();
 		}
 		return totalCost;
 	}
-	
-	public double getTotalRevenue(){
-		double totalRevenue = getTotalSales() - getTotalCost();
-		if (totalRevenue <= 0) {
-			throw new IllegalStateException("Total revenue have to be positive");
-		}
-		return totalRevenue;
+
+	/**
+	 * この販売による利益（売り上げ-原価）を返す。このメソッドは値引きを考慮しない
+	 * @return double 利益金額
+	 */
+	public double getTotalRevenue() {
+		return getTotalSales() - getTotalCost();
 	}
-	
+
 	public Date getSalesDate(){
 		return salesDate;
 	}
-	
-	public double getDiscountValue() {
-		return discountValue;
-	}
-	
+
+	/**
+	 * この販売のお客さんの属性を設定する
+	 * @param attribute 属性文字列
+	 */
 	public void setUserAttribute(String attribute){
 		if (attribute == null || attribute.length() == 0) {
 			throw new IllegalArgumentException("User attribute is illegal");
 		}
 		this.userAttribute = attribute;
 	}
-	
+
+	/**
+	 * この販売のお客さんの属性を返す
+	 * @return String
+	 */
 	public String getUserAttribute(){
 		return userAttribute;
 	}

--- a/AndroidPOS/src/com/ricoh/pos/data/WomanShopSalesDef.java
+++ b/AndroidPOS/src/com/ricoh/pos/data/WomanShopSalesDef.java
@@ -2,7 +2,7 @@ package com.ricoh.pos.data;
 
 public enum WomanShopSalesDef {
     DATE("sales_date"),          // 販売日
-    DISCOUNT("discount"),        // その商談での割り引き率
+    DISCOUNT("discount"),        // この商談全体での割り引き額
     USER_AGES("user_ages");     // お客さんの年代
 
     private String name;

--- a/AndroidPOS/src/com/ricoh/pos/data/WomanShopSalesOrderDef.java
+++ b/AndroidPOS/src/com/ricoh/pos/data/WomanShopSalesOrderDef.java
@@ -12,6 +12,7 @@ public enum WomanShopSalesOrderDef {
     PURCHASE_PRICE("purchase_price"),   // 仕入れ価格(CSVではunit_selling_price)
     UNIT_PRICE("unit_price"),           // 商品単価(CSVではMRP)
     QTY("sales_count"),                  // 販売できた数量
+    DISCOUNT("discount"),               // このOrderに設定された値引き額
     SINGLE_SALES_ID("single_sales_id");// 親にあたる販売情報のID
 
     private String name;

--- a/AndroidPOS/src/com/ricoh/pos/model/WomanShopSalesIOManager.java
+++ b/AndroidPOS/src/com/ricoh/pos/model/WomanShopSalesIOManager.java
@@ -61,6 +61,7 @@ public class WomanShopSalesIOManager {
             SalesDatabaseHelper.WS_SALES_ORDER_TABLE_NAME + "." + WomanShopSalesOrderDef.PURCHASE_PRICE.name(),
             SalesDatabaseHelper.WS_SALES_ORDER_TABLE_NAME + "." + WomanShopSalesOrderDef.UNIT_PRICE.name(),
             SalesDatabaseHelper.WS_SALES_ORDER_TABLE_NAME + "." + WomanShopSalesOrderDef.QTY.name(),
+            SalesDatabaseHelper.WS_SALES_ORDER_TABLE_NAME + "." + WomanShopSalesOrderDef.DISCOUNT.name(),
             SalesDatabaseHelper.WS_SALES_ORDER_TABLE_NAME + "." + WomanShopSalesOrderDef.SINGLE_SALES_ID.name()
     };
 
@@ -132,13 +133,14 @@ public class WomanShopSalesIOManager {
                 + combinedColumns[6] + ", "
                 + combinedColumns[7] + ", "
                 + combinedColumns[8] + ", "
-                + combinedColumns[9]
+                + combinedColumns[9] + ", "
+                + combinedColumns[10]
                 + " from " +  SalesDatabaseHelper.WS_SALES_TABLE_NAME
                 + " left join "
                 +  SalesDatabaseHelper.WS_SALES_ORDER_TABLE_NAME
                 + " on "
                 + SalesDatabaseHelper.WS_SALES_TABLE_NAME + ".ROWID = "
-                + combinedColumns[9];
+                + combinedColumns[10];
     }
 
 
@@ -161,16 +163,16 @@ public class WomanShopSalesIOManager {
             cursor.moveToFirst();
             for (int i = 0; i < cursor.getCount(); i++) {
                 if (record == null) {
-                    sales_id = cursor.getInt(9);
+                    sales_id = cursor.getInt(10);
                     Date salesDate = DATE_FORMAT.parse(cursor.getString(0));
 
                     record = new SingleSalesRecord(salesDate);
                     record.setDiscountValue(cursor.getDouble(1));
                     record.setUserAttribute(cursor.getString(2));
-                } else if (sales_id != cursor.getInt(9)) {
+                } else if (sales_id != cursor.getInt(10)) {
                     sales.add(record);
 
-                    sales_id = cursor.getInt(9);
+                    sales_id = cursor.getInt(10);
                     Date salesDate = DATE_FORMAT.parse(cursor.getString(0));
                     record = new SingleSalesRecord(salesDate);
                     record.setDiscountValue(cursor.getDouble(1));
@@ -182,6 +184,7 @@ public class WomanShopSalesIOManager {
                 product.setOriginalCost(cursor.getDouble(6));
                 product.setPrice(cursor.getDouble(7));
                 Order order = new Order(product, cursor.getInt(8));
+                order.setDiscount(cursor.getDouble(9));
                 record.addOrder(order);
                 cursor.moveToNext();
             }
@@ -251,16 +254,16 @@ public class WomanShopSalesIOManager {
             for (int i = 0; i < cursor.getCount(); i++)
             {
                 if (record == null) {
-                    sales_id = cursor.getInt(9);
+                    sales_id = cursor.getInt(10);
                     Date salesDate = DATE_FORMAT.parse(cursor.getString(0));
                     record = new SingleSalesRecord(salesDate);
                     record.setDiscountValue(cursor.getDouble(1));
                     record.setUserAttribute(cursor.getString(2));
                 }
-                else if (sales_id != cursor.getInt(9)) {
+                else if (sales_id != cursor.getInt(10)) {
                     sales.add(record);
 
-                    sales_id = cursor.getInt(9);
+                    sales_id = cursor.getInt(10);
                     Date salesDate = DATE_FORMAT.parse(cursor.getString(0));
                     record = new SingleSalesRecord(salesDate);
                     record.setDiscountValue(cursor.getDouble(1));
@@ -272,6 +275,7 @@ public class WomanShopSalesIOManager {
                 product.setOriginalCost(cursor.getDouble(6));
                 product.setPrice(cursor.getDouble(7));
                 Order order = new Order(product, cursor.getInt(8));
+                order.setDiscount(cursor.getDouble(9));
                 record.addOrder(order);
                 cursor.moveToNext();
             }
@@ -325,6 +329,7 @@ public class WomanShopSalesIOManager {
                 orderRecord.put(WomanShopSalesOrderDef.PURCHASE_PRICE.name(), product.getOriginalCost());
                 orderRecord.put(WomanShopSalesOrderDef.UNIT_PRICE.name(), product.getPrice());
                 orderRecord.put(WomanShopSalesOrderDef.QTY.name(), order.getNumberOfOrder());
+                orderRecord.put(WomanShopSalesOrderDef.DISCOUNT.name(), order.getDiscount());
                 orderRecord.put(WomanShopSalesOrderDef.SINGLE_SALES_ID.name(), rowID);
 
                 salesDatabase.insertWithOnConflict(
@@ -467,7 +472,7 @@ public class WomanShopSalesIOManager {
                                 + order.getNumberOfOrder() + ","
                                 + String.format("%.2f", product.getPrice()) + ","
                                 + String.format("%.2f", product.getPrice() * order.getNumberOfOrder()) + ","
-                                + String.format("%.2f", record.getDiscountValue()) + ","
+                                + String.format("%.2f", order.getDiscount()) + ","
                                 + record.getSalesDate().toString() + ","
                                 + record.getUserAttribute() + "\n";
 


### PR DESCRIPTION
計算：
- 値引き額/（売り上げ-原価）で、値引き額が本来の利益に占める割合を出して、各Orderに利益x値引き
  割＝Orderごとの値引き額を出す。
  *Order毎の値引き額の合計と、最初に提示された合計値引き額に差異（誤差）が出たら、その分を先頭のOrderの値引き額に加算して補正する。

その他変更：
- DBのWomanShopSalesOrderDefに、Order単位の値引き額を設定するカラムを追加。
- SQLiteへの検索、登録、CSVエクスポート時にOrderの値引き額を扱えるよう修正

https://developer.osaroid.info/jira/browse/BOP-44
