### PR TITLE
BOP-60 販売画面で、全ての商品を0件にしたあとcancelボタンを押下すると、アプリが落ちる の対応

### DIFF
--- a/AndroidPOS/res/values/strings.xml
+++ b/AndroidPOS/res/values/strings.xml
@@ -16,7 +16,7 @@
     <string name="original_cost_label">Cost</string>
     <string name="currency_india">Rp</string>
     <string name="number_tag">X</string>
-    <string name="discount_error">Check discounted price because it is larger than the profit.</string>
+    <string name="discount_error">Discount must be less than the profit.</string>
     <string name="discount">Discount</string>
     <string name="zero_order_error">Input number of products</string>
     <string name="title_oneday_total_sales">Total Sales</string>

--- a/AndroidPOS/src/com/ricoh/pos/RegisterConfirmActivity.java
+++ b/AndroidPOS/src/com/ricoh/pos/RegisterConfirmActivity.java
@@ -91,7 +91,6 @@ public class RegisterConfirmActivity extends FragmentActivity
 
 	@Override
 	public void onCancelClicked() {
-		RegisterManager.getInstance().updateDiscountValue(0);
 		finish();
 	}
 
@@ -105,6 +104,7 @@ public class RegisterConfirmActivity extends FragmentActivity
 		super.onDestroy();
 		salesDatabase.close();
 		salesDatabaseHelper.close();
+		RegisterManager.getInstance().clearDiscountValue();
 		Log.d("debug", "Exit RegisterConfirmActivity onDestroy");
 	}
 

--- a/AndroidPOS/src/com/ricoh/pos/model/RegisterManager.java
+++ b/AndroidPOS/src/com/ricoh/pos/model/RegisterManager.java
@@ -222,4 +222,8 @@ public class RegisterManager {
 		return record;
 	}
 
+	public void clearDiscountValue() {
+		this.discountValue = 0;
+	}
+
 }


### PR DESCRIPTION
・利益額を超えた値引きをした際のエラーメッセージを変更しました。
・キャンセルボタン押下時の値引き額チェックをなくし、RegisterConfirmActivity終了時に値引き額をリセットするように修正しました。

https://developer.osaroid.info/jira/browse/BOP-60
