### PR TITLE
BOP-58 import と export で処理を分ける。片方が失敗してももう一方が成功するようにする

### DIFF
--- a/AndroidPOS/res/values/strings.xml
+++ b/AndroidPOS/res/values/strings.xml
@@ -7,8 +7,9 @@
     <string name="title_total_payment">Total</string>
     <string name="category_title_default">ALL</string>
     <string name="sync_success">Succeeded to import/export</string>
-    <string name="sd_import_error">Failed to import from SD!</string>
-    <string name="sd_export_error">Failed to export to SD!</string>
+    <string name="sd_import_error">Failed to import from SD! But export to SD success.</string>
+    <string name="sd_export_error">Import from SD success. But failed to export to SD!</string>
+    <string name="sd_import_export_error">Failed import and export with SD!</string>
     <string name="dialog_data_syncro_message">Under synchronizing. Please wait</string>
     <string name="ok">OK</string>
     <string name="cancel">Cancel</string>

--- a/AndroidPOS/src/com/ricoh/pos/MainMenuActivity.java
+++ b/AndroidPOS/src/com/ricoh/pos/MainMenuActivity.java
@@ -34,7 +34,8 @@ public class MainMenuActivity extends Activity implements DataSyncTaskCallback {
 		findViewById(R.id.RegisterButton).setOnClickListener(new OnClickListener() {
 			@Override
 			public void onClick(View v) {
-				Intent intent = new Intent().setClass(MainMenuActivity.this,
+				Intent intent = new Intent().setClass(
+						MainMenuActivity.this,
 						CategoryListActivity.class);
 				startActivity(intent);
 			}
@@ -44,8 +45,7 @@ public class MainMenuActivity extends Activity implements DataSyncTaskCallback {
 		findViewById(R.id.SalesButton).setOnClickListener(new OnClickListener() {
 			@Override
 			public void onClick(View v) {
-				Intent intent = new Intent().setClass(MainMenuActivity.this,
-						SalesCalenderActivity.class);
+				Intent intent = new Intent().setClass(MainMenuActivity.this, SalesCalenderActivity.class);
 				startActivity(intent);
 			}
 		});
@@ -53,8 +53,10 @@ public class MainMenuActivity extends Activity implements DataSyncTaskCallback {
 		findViewById(R.id.SyncButton).setOnClickListener(new OnClickListener() {
 			@Override
 			public void onClick(View v) {
-				DataSyncTask syncTask = new DataSyncTask(MainMenuActivity.this,
-						MainMenuActivity.this, womanShopIOManager);
+				DataSyncTask syncTask = new DataSyncTask(
+						MainMenuActivity.this,
+						MainMenuActivity.this,
+						womanShopIOManager);
 				syncTask.execute();
 			}
 		});

--- a/AndroidPOS/src/com/ricoh/pos/model/WomanShopSalesIOManager.java
+++ b/AndroidPOS/src/com/ricoh/pos/model/WomanShopSalesIOManager.java
@@ -401,8 +401,9 @@ public class WomanShopSalesIOManager {
 			// FIXME;全件でいいの？ある日付け以降とかでなく。
 			ArrayList<SingleSalesRecord> records = this.searchAll();
 			writeSalesData(context, records);
-		} catch (Exception e) {
+		} catch (IOException e) {
 			Log.d("debug", "exportCSV Exception occuered.", e);
+			throw e;
 		}
 	}
 


### PR DESCRIPTION
inport/export時に、片方がエラーになってもとりあえず最後まで実行してみるように変更。
これにより、importが失敗してもexportを実行する。
また、どちらかが失敗or 両方失敗でメッセージを変更するようにした。
import/exportに失敗しても、その時のDBの内容で商品画面が表示できるようになった。

元チケット：https://developer.osaroid.info/jira/browse/BOP-58
