### PR TITLE
BOP-99-2 商品名がカテゴリ名になっている（再修正）

### DIFF
--- a/AndroidPOS/src/com/ricoh/pos/data/Product.java
+++ b/AndroidPOS/src/com/ricoh/pos/data/Product.java
@@ -26,7 +26,7 @@ public class Product {
 	private static String imageStorageFolder = "/Ricoh";
 
 	public Product(String code, String name, String category, long originalCost, long price) {
-		this(code, category, name, originalCost, price, 0);
+		this(code, name, category, originalCost, price, 0);
 	}
 
 	public Product(String code, String name, String category, long originalCost, long price, int stock) {


### PR DESCRIPTION
元チケット：https://developer.osaroid.info/jira/browse/BOP-99

BOP-66のマージ時にBOP-99の修正が上書きされていたので再修正。

NEXUS９で動作確認済み
