### PR TITLE
BOP-66 リリース時障害対応

### DIFF
--- a/AndroidPOS/src/com/ricoh/pos/data/WomanShopFormatter.java
+++ b/AndroidPOS/src/com/ricoh/pos/data/WomanShopFormatter.java
@@ -53,6 +53,7 @@ public class WomanShopFormatter {
 	public static long convertRupeeToPaisa(double rupee)
 	{
 		BigDecimal discount = new BigDecimal(rupee);
-		return discount.scaleByPowerOfTen(2).longValue();
+		// doubleからの変換なので、四捨五入で有効桁をパイサの範囲に変更してからスケールアップ
+		return discount.setScale(2, BigDecimal.ROUND_HALF_UP).scaleByPowerOfTen(2).longValue();
 	}
 }


### PR DESCRIPTION
元チケット：https://developer.osaroid.info/jira/browse/BOP-106
- DB移行時にdoubleの値をlongに変換する際、パイサ相当の有効桁に丸めてから桁移行をしていなかったために誤差を生じていた。
- 移行処理の際に有効桁を設定する処理を追加
- リリース時テストを再実行して問題ないことを確認
